### PR TITLE
Various fixes in build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ _*
 build
 CMakeFiles
 *.pptx
+3rd_64

--- a/src/Annotation/VipLibRIR.cpp
+++ b/src/Annotation/VipLibRIR.cpp
@@ -968,7 +968,7 @@ VipLibRIR* VipLibRIR::instance()
 		}
 		librir->open_with_filename = (_open_with_filename)westLib()->resolve("open_with_filename");
 		if (!librir->open_with_filename) {
-			VIP_LOG_ERROR("librir: missing open_camera_filename");
+			VIP_LOG_ERROR("librir: missing open_with_filename");
 			delete librir;
 			return librir = nullptr;
 		}

--- a/src/External/west_plugins/CMakeLists.txt
+++ b/src/External/west_plugins/CMakeLists.txt
@@ -1,7 +1,6 @@
-if(WIN32)
-	add_subdirectory(NVF)
-	add_subdirectory(AIA)
-	add_subdirectory(Tokida)
-endif()
-
-add_subdirectory(WEST)
+file(GLOB V_GLOB LIST_DIRECTORIES true "*")
+foreach(item ${V_GLOB})
+	if(IS_DIRECTORY ${item})
+		add_subdirectory(${item})
+	endif()
+endforeach()

--- a/src/Plugins/Python/CMakeLists.txt
+++ b/src/Plugins/Python/CMakeLists.txt
@@ -41,15 +41,15 @@ target_compile_definitions(Python PRIVATE "PY_ARRAY_UNIQUE_SYMBOL=NUMPY_SYMBOL")
 
 
 # configure CPython
-if(DEFINED ENV{VIP_PYTHON_HOME} AND DEFINED ENV{VIP_PYTHON_VERSION})
-	# Use env. variables VIP_PYTHON_HOME (interpreter folder) and VIP_PYTHON_VERSION (like '38') to link to a specific python version
-	message(STATUS "VIP_PYTHON_HOME is defined and set to $ENV{VIP_PYTHON_HOME}")
+if(DEFINED ENV{VIP_PYTHONHOME} AND DEFINED ENV{VIP_PYTHON_VERSION})
+	# Use env. variables VIP_PYTHONHOME (interpreter folder) and VIP_PYTHON_VERSION (like '38') to link to a specific python version
+	message(STATUS "VIP_PYTHONHOME is defined and set to $ENV{VIP_PYTHONHOME}")
 	message(STATUS "Linking with python$ENV{VIP_PYTHON_VERSION}")
-	target_include_directories(Python PRIVATE "$ENV{VIP_PYTHON_HOME}/include" "$ENV{VIP_PYTHON_HOME}/Lib/site-packages/numpy/core/include" )
-	target_link_directories(Python PRIVATE "$ENV{VIP_PYTHON_HOME}/libs")
+	target_include_directories(Python PRIVATE "$ENV{VIP_PYTHONHOME}/include" "$ENV{VIP_PYTHONHOME}/Lib/site-packages/numpy/core/include" )
+	target_link_directories(Python PRIVATE "$ENV{VIP_PYTHONHOME}/libs")
 	target_link_libraries(Python PRIVATE python$ENV{VIP_PYTHON_VERSION})
 		
-	SET(PYTHON_RUNTIME $ENV{VIP_PYTHON_HOME})
+	SET(PYTHON_RUNTIME $ENV{VIP_PYTHONHOME})
 	
 else()
 	# Use find_package to get the Python paths
@@ -65,7 +65,7 @@ else()
 	
 	target_compile_definitions(Python PRIVATE "VIP_PYTHON_SHARED_LIB=\"${Python_LIBRARIES}\"")
 	
-	#target_compile_definitions(Python PRIVATE "VIP_PYTHONHOME=$ENV{VIP_PYTHON_HOME}")
+	#target_compile_definitions(Python PRIVATE "VIP_PYTHONHOME=$ENV{VIP_PYTHONHOME}")
 	
 	SET(PYTHON_RUNTIME ${Python_RUNTIME_LIBRARY_DIRS})	
 


### PR DESCRIPTION
When a python distribution installed on your PC. `numpy` can't get loaded properly because of a mismatch with DLLs. This PR fixes mainly that with additional minor fixes.